### PR TITLE
Add a bucket listing GET method and a test

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pip install -e .[docs]
 To work on tests:
 
 ```
-pip install -e .[tests]
+pip install -e .[test]
 ```
 
 To run the linter and githook:

--- a/src/os_api/api.py
+++ b/src/os_api/api.py
@@ -89,6 +89,18 @@ async def main() -> RedirectResponse:
     return RedirectResponse(url="/docs")
 
 
+@app.get("/list-buckets/")
+async def list_buckets() -> JSONResponse:
+    "Endpoint to create a new bucket in the server."
+    s3 = boto3_client()
+    bucket_names = [n["Name"] for n in s3.list_buckets()["Buckets"]]
+    try:
+        return JSONResponse(status_code=200, content=bucket_names)
+    except Exception as err:
+        logging.info(err)
+        return JSONResponse(status_code=500, content=f"Error while listing buckets: {str(err)}")
+
+
 @app.post("/create-bucket/", tags=["Data"])
 async def create_bucket(bucket_name: str = Query("", description="")) -> JSONResponse:
     "Endpoint to create a new bucket in the server."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 
+
 @pytest.fixture
 def fixture_dir():
     """
@@ -14,4 +15,4 @@ def text_file(fixture_dir):
     """
     Sample text file
     """
-    return open(os.path.join(fixture_dir, "1_test.txt"), 'rb')
+    return open(os.path.join(fixture_dir, "1_test.txt"), "rb")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,7 @@ is there much value or do we end up testing FastAPI?
 
 At level of "do endpoints exist, and resolve"
 """
+
 import os
 from os_api.api import app, s3_endpoint
 import pytest
@@ -14,9 +15,11 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from moto import mock_aws
 import logging
+
 logging.basicConfig(level=logging.INFO)
 
 from moto.server import ThreadedMotoServer
+
 
 @pytest.fixture(scope="module")
 def moto_server():
@@ -25,9 +28,10 @@ def moto_server():
     server = ThreadedMotoServer(port=0)
     server.start()
     host, port = server.get_host_and_port()
-    os.environ['AWS_URL_ENDPOINT'] = f"http://{host}:{port}"
+    os.environ["AWS_URL_ENDPOINT"] = f"http://{host}:{port}"
     yield f"http://{host}:{port}"
     server.stop()
+
 
 # Without both the dependency override _and_ the environment variable set in the fixture,
 # the endpoint URL doesn't get set for the API properly - wish i fully understood why! - JW
@@ -35,39 +39,52 @@ app.dependency_overrides[s3_endpoint] = moto_server
 
 client = TestClient(app)
 
+
 def test_read_main():
     response = client.get("/")
     assert response.status_code == 200
 
 
 def test_create_bucket(moto_server):
-    params = {'bucket_name': 'test_bucket'}
-    response = client.post('/create-bucket/', params=params)
+    params = {"bucket_name": "test_bucket"}
+    response = client.post("/create-bucket/", params=params)
     assert response.status_code == 200
 
 
 def test_generate_presigned_url(moto_server):
-    params = {'filename': 'demo.txt', 
-              'file_type': 'text/plain',
-              'bucket_name': 'test_bucket'}
-    response = client.post('/generate-presigned-url/', data=params)
+    params = {
+        "filename": "demo.txt",
+        "file_type": "text/plain",
+        "bucket_name": "test_bucket",
+    }
+    response = client.post("/generate-presigned-url/", data=params)
     assert response.status_code == 200
 
 
 def test_upload(text_file):
-    data = {'bucket_name': 'test_bucket'}
-    response = client.post('/create-bucket/', params=data)
-    response = client.post('/upload/', data=data, files=[('files', text_file)])
+    data = {"bucket_name": "test_bucket"}
+    response = client.post("/create-bucket/", params=data)
+    response = client.post("/upload/", data=data, files=[("files", text_file)])
     assert response.status_code == 200
 
 
 def test_check_file_exist(text_file):
-    data = {'bucket_name': 'test_bucket'}
-    response = client.post('/create-bucket/', params=data)
-    response = client.post('/upload/', data=data, files=[('files', text_file)])
-    data['filename'] = "1_test.txt"
-    response = client.post('/check-file-exist/', data=data)
+    data = {"bucket_name": "test_bucket"}
+    response = client.post("/create-bucket/", params=data)
+    response = client.post("/upload/", data=data, files=[("files", text_file)])
+    data["filename"] = "1_test.txt"
+    response = client.post("/check-file-exist/", data=data)
     assert response.status_code == 200
+
+
+def test_list_buckets():
+    buckets = ["hello", "world"]
+    for b in buckets:
+        client.post("/create-bucket/", params={"bucket_name": b})
+    res = client.get("/list-buckets/")
+    bucket_list = res.json()
+    for b in buckets:
+        assert b in bucket_list
 
 
 def test_import_api_module():


### PR DESCRIPTION
* Adds a GET interface with no parameters that runs `list_buckets` against the endpoint and returns a list
* Minimal error handling, should really extend to cases where we don't have `s3:ListAllMyBuckets` permission
* Adds a test using `moto_server` to mock the success case

Completes #4 

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/list_buckets.html

Hope this is ok @albags - wanted to get in a small change to aid with data exploration...

