### PR TITLE
Add a dockerfile and lines in the README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,16 @@
-# Build virtualenv
-FROM python:3.12-slim as build
-WORKDIR /app
-COPY pyproject.toml README.md /app/
-COPY src /app/src
-COPY .git /app/.git
-RUN pip install --upgrade pip pdm
-# Installs the codebase in editable mode into .venv
-RUN pdm install
+FROM python:3.12
 
-# Build production containerdocker
-# Only the ./.venv ./src ./tests are present in the production image
-FROM python:3.12-slim as prod
-WORKDIR /app
-RUN groupadd -g 999 python && \
-    useradd -m -r -u 999 -g python python
-RUN chown python:python /app
-COPY --chown=python:python --from=build /app/.venv /app/.venv
-COPY --chown=python:python --from=build /app/src /app/src
-COPY --chown=python:python tests/ /app/tests
 
-USER python
-ENV PATH="/app/.venv/bin:$PATH"
-ENV VIRTUAL_ENV="/app/.venv"
-CMD ["python", "-m", "os_api"]
+WORKDIR /code
+
+
+COPY ./requirements.txt /code/requirements.txt
+
+
+RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+
+
+COPY ./src /code/app
+
+
+CMD ["fastapi", "run", "app/os_api/api.py", "--port", "80"]

--- a/README.md
+++ b/README.md
@@ -115,13 +115,21 @@ AWS_URL_ENDPOINT="url goes here"
 
 This will bring up the OpenAPI documentation on localhost:8080
 
-### With uvicorn / nginx 
+### With `uvicorn` using the `fastapi` cli 
 
-TBD
+`fastapi run --workers 4 src/os_api/api.py`
 
-### In docker
+### In a container
 
-TBD if this proves useful - current deployment target is Posit Connect
+#### docker
+
+`docker build -t os_api .`
+`docker run -f -p 80:80 os_api`
+
+#### podman
+
+`podman build -t os_api .`
+`podman run --env-file=.env -p=8000 --expose=8000 os_api`
 
 ### Automatic Versioning
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "aioboto3",
     "boto3",
     "botocore",
-    "fastapi",
+    "fastapi[standard]",
     "python-multipart",
     "python-dotenv",
     "uvicorn",

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ click==8.1.7
     # via uvicorn
 dulwich==0.22.1
     # via autosemver
-fastapi==0.112.0
+fastapi[standard]==0.112.0
     # via os_api (pyproject.toml)
 frozenlist==1.4.1
     # via

--- a/src/os_api/api.py
+++ b/src/os_api/api.py
@@ -168,7 +168,7 @@ async def upload(
         tasks = [upload_file(bucket_name, key, file) for file in files]
         await asyncio.gather(*tasks)
     except Exception as e:
-        logger.error("Error:", e)
+        logger.error(f"Error: {e}")
         return JSONResponse(status_code=500, content={str(e)})
 
     end_time = perf_counter()

--- a/src/os_api/api.py
+++ b/src/os_api/api.py
@@ -19,7 +19,7 @@ from fastapi.responses import JSONResponse, RedirectResponse
 # Configure logging
 logging.basicConfig(
     filename="upload_logs.log",  # Log file path on the server
-    level=logging.INFO,  # Log level
+    level=logging.DEBUG,  # Log level
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 
@@ -168,7 +168,7 @@ async def upload(
         tasks = [upload_file(bucket_name, key, file) for file in files]
         await asyncio.gather(*tasks)
     except Exception as e:
-        print("Error:", e)
+        logger.error("Error:", e)
         return JSONResponse(status_code=500, content={str(e)})
 
     end_time = perf_counter()


### PR DESCRIPTION
Update the Dockerfile to run the API in a container, following the pattern here:

https://fastapi.tiangolo.com/deployment/docker/

Adds a couple of lines in the README for building with `docker` or `podman`

Linked to [this issue about running the API for managing plankton imagery](https://github.com/NERC-CEH/plankton_ml/issues/30) 